### PR TITLE
Implements the u2f helper method in the gem

### DIFF
--- a/lib/generators/devise_fido_usf/install_generator.rb
+++ b/lib/generators/devise_fido_usf/install_generator.rb
@@ -26,12 +26,6 @@ module DeviseFidoUsf
 
       end
 
-      def add_application_helper
-        in_root do
-          inject_into_module "app/helpers/application_helper.rb", ApplicationHelper, application_helper_data
-        end
-      end
-
       def copy_locale
         copy_file "../../../config/locales/en.yml", "config/locales/fido_usf.en.yml"
       end
@@ -43,17 +37,6 @@ module DeviseFidoUsf
       def show_readme
         readme("README") if behavior == :invoke
       end
-
-      def application_helper_data
-<<RUBY
-
-  def u2f
-    # use base_url as app_id, e.g. 'http://localhost:3000'
-    @u2f ||= U2F::U2F.new(request.base_url)
-  end
-RUBY
-      end
     end
   end
 end
-

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -1,42 +1,28 @@
-require "test_helper"
+require 'test_helper'
 
 class InstallGeneratorTest < Rails::Generators::TestCase
   tests DeviseFidoUsf::Generators::InstallGenerator
-  destination File.expand_path("../../tmp", __FILE__)
+  destination File.expand_path('../../tmp', __FILE__)
 
   setup do
     prepare_destination
     copy_app_files
   end
 
-  test "assert all files are properly created" do
-    assert_file "app/helpers/application_helper.rb" do |content|
-      assert_no_match "def u2f", content
-    end
-    run_generator(["--orm=active_record"])
-    assert_file "config/locales/fido_usf.en.yml"
-    assert_file "app/helpers/application_helper.rb" do |content|
-      assert_match "def u2f", content
-    end
-    assert_migration "db/migrate/create_fido_usf_devices.rb", /def change/
+  test 'assert all files are properly created' do
+    run_generator(['--orm=active_record'])
+    assert_file 'config/locales/fido_usf.en.yml'
+    assert_migration 'db/migrate/create_fido_usf_devices.rb', /def change/
   end
 
-  test "fails if no ORM is specified" do
-    assert_file "app/helpers/application_helper.rb" do |content|
-      assert_no_match "def u2f", content
-    end
-
+  test 'fails if no ORM is specified' do
     stderr = capture(:stderr) do
       run_generator
     end
 
-    assert_match %r{An ORM must be set to install Devise}, stderr
+    assert_match(/An ORM must be set to install Devise/, stderr)
 
-    assert_no_file "config/locales/fido_usf.en.yml"
-    assert_no_migration "db/migrate/create_fido_usf_devices.rb"
-    assert_file "app/helpers/application_helper.rb" do |content|
-      assert_no_match "def u2f", content
-    end
+    assert_no_file 'config/locales/fido_usf.en.yml'
+    assert_no_migration 'db/migrate/create_fido_usf_devices.rb'
   end
 end
-


### PR DESCRIPTION
* Adds the u2f method in the controllers
* Removes the u2f implementation in the generator

-----

@CyberDeck I followed the instructions from the `README.md` file but it didn't worked. For some reasons, the `u2f` helper, inserted in my `ApplicationHelper` module, wasn't found by the gem and was failing.

I started to investigate why the generate was adding this method, but I wasn't able to figure it out. I was thinking of the `request.base_url` which would have been wrong from the gem, so it was added within my application, but the `request` object stays as it is, no matter where is the controller, so I just added the method in the controllers and all is working fine.

Can you please tell me if I'm wrong somewhere? Otherwise, if you agree with this, I can create a concern in order to move the method out of the controllers and avoid duplications so that the code is cleaner.

Let me know what's best in your opinion.