### PR TITLE
Allows to disable this gem on a User instance

### DIFF
--- a/lib/devise_fido_usf/controllers/helpers.rb
+++ b/lib/devise_fido_usf/controllers/helpers.rb
@@ -26,24 +26,33 @@ module DeviseFidoUsf
       end
 
       def check_request_and_redirect_to_verify_fido_usf
-        if signed_in?(resource_name) && warden.session(resource_name)[:with_fido_usf_authentication]
+        if signed_in?(resource_name) &&
+           warden.session(resource_name)[:with_fido_usf_authentication]
           # login with 2fa
           id = warden.session(resource_name)[:id]
 
+          remember_me = Devise::TRUE_VALUES.include?(remember_me_from_params)
           return_to = session["#{resource_name}_return_to"]
-          remember_me = Devise::TRUE_VALUES.include?(sign_in_params[:remember_me])
+
           sign_out
 
-          # It is secure to put these information in a Rails 5 session
-          # because cookies are signed and encrypted.
-          session["#{resource_name}_id"] = id
-          session["#{resource_name}_remember_me"] = remember_me
-          session["#{resource_name}_password_checked"] = true
-          session["#{resource_name}_return_to"] = return_to if return_to
+          update_session_with!(id, remember_me, return_to)
 
           redirect_to verify_fido_usf_path_for(resource_name)
-          return
         end
+      end
+
+      def remember_me_from_params
+        sign_in_params[:remember_me]
+      end
+
+      def update_session_with!(id, remember_me, return_to)
+        # It is secure to put these information in a Rails 5 session
+        # because cookies are signed and encrypted.
+        session["#{resource_name}_id"] = id
+        session["#{resource_name}_remember_me"] = remember_me
+        session["#{resource_name}_password_checked"] = true
+        session["#{resource_name}_return_to"] = return_to if return_to
       end
 
       def verify_fido_usf_path_for(resource_or_scope = nil)

--- a/lib/devise_fido_usf/hooks/fido_usf_authenticatable.rb
+++ b/lib/devise_fido_usf/hooks/fido_usf_authenticatable.rb
@@ -1,10 +1,14 @@
 Warden::Manager.after_authentication do |user, auth, options|
-  if user.respond_to?(:with_fido_usf_authentication?)
-    with_fido_usf_authentication = user.with_fido_usf_authentication?()
-    auth.session(options[:scope])[:with_fido_usf_authentication] = with_fido_usf_authentication
-    if with_fido_usf_authentication
-      auth.session(options[:scope])[:id] = user.id
+  u2fauth_enabled = true
+  u2fauth_enabled = user.u2fauth_enabled? if user.respond_to?(:u2fauth_enabled?)
+
+  if u2fauth_enabled
+    if user.respond_to?(:with_fido_usf_authentication?)
+      with_fido_usf_authentication = user.with_fido_usf_authentication?
+      scope = auth.session(options[:scope])
+      scope[:with_fido_usf_authentication] = with_fido_usf_authentication
+
+      scope[:id] = user.id if with_fido_usf_authentication
     end
   end
 end
-

--- a/test/dummy/app/models/concerns/has_additionnal_u2f_methods.rb
+++ b/test/dummy/app/models/concerns/has_additionnal_u2f_methods.rb
@@ -1,0 +1,7 @@
+module HasAdditionnalU2fMethods
+  extend ActiveSupport::Concern
+
+  def u2fauth_enabled?
+    false
+  end
+end


### PR DESCRIPTION
This is useful when using different 2fa gems and allowing the user to choose which one he'd like to use.

----

To give more information about this change, in my application I'm forcing the user to select a 2fa method (Google Authenticator and Fido U2F), but I want them to choose which one they'd like.
The first time they connect, I want to show them page where they can choose they're preferred method.

The [devise_google_authenticator](https://github.com/AsteriskLabs/devise_google_authenticator) gem is already managing a `gauth_enabled?` attribute on the User instance, so I added the same in this gem so that my workflow is the following:

1. Request received
2. Devise Google Authenticator gem checks `gauth_enabled?`
3. Device Fido UI2f gem checks `u2fauth_enabled?`
4. A No2Fa module I wrote is reached and redirects to the page to choose the authentication method

After the user selected one of the 2 methods, the same workflow is executed, but stops at the devise module which gets enabled.