### PR TITLE
Fixes generated database migration script (Fixes #3)

### DIFF
--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -2,13 +2,13 @@ class Create<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_ve
   def change
     create_table :<%= table_name %> do |t|
       t.references  :user,                  null: false, polymorphic: true, index: true
-      t.string      :name,                  null: false, default: ""
-      t.string      :key_handle,            null: false, limit: 255, default: ""
-      t.binary      :public_key,            null: false, limit: 10.kilobytes, default: ""
-      t.binary      :certificate,           null: false, limit: 1.megabyte, default: ""
+      t.string      :name,                  null: false, default: ''
+      t.string      :key_handle,            null: false, limit: 255, default: ''
+      t.binary      :public_key,            null: false, limit: 10.kilobytes
+      t.binary      :certificate,           null: false, limit: 1.megabyte
       t.integer     :counter,               null: false, default: 0
       t.timestamp   :last_authenticated_at, null: false
-<% attributes.each do |attribute| -%> 
+<% attributes.each do |attribute| -%>
       t.<%= attribute.type %> :<%= attribute.name %>
 <% end -%>
       t.timestamps


### PR DESCRIPTION
The generated migration script was trying to set a default value to binary fields which isn't possible with MySQL and potentially with some other databases. This commit removes the default value.