### PR TITLE
Allows using this gem with other models than User

### DIFF
--- a/app/controllers/devise/fido_usf_registrations_controller.rb
+++ b/app/controllers/devise/fido_usf_registrations_controller.rb
@@ -1,10 +1,10 @@
 class Devise::FidoUsfRegistrationsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_resource!
 
   def new
     @registration_requests = u2f.registration_requests
     session[:challenges] = @registration_requests.map(&:challenge)
-    key_handles = current_user.fido_usf_devices.map(&:key_handle)
+    key_handles = resource.fido_usf_devices.map(&:key_handle)
     @sign_requests = u2f.authentication_requests(key_handles)
     @app_id = u2f.app_id
     render :new
@@ -12,19 +12,21 @@ class Devise::FidoUsfRegistrationsController < ApplicationController
 
   # Show a list of all registered devices
   def show
-    @devices = current_user.fido_usf_devices.all
+    @devices = resource.fido_usf_devices.all
     render :show
   end
 
   def destroy
-    device = current_user.fido_usf_devices.find(params[:id])
-    @fade_out_id = device.id
+    device = resource.fido_usf_devices.find(params[:id])
+    @fade_out_id = device.id unless params[:on_success_redirect_to]
     device.destroy
-    @devices = current_user.fido_usf_devices.all
+    unless params[:on_success_redirect_to]
+      @devices = resource.fido_usf_devices.all
+    end
     flash[:success] = I18n.t('fido_usf.flashs.device.removed')
     respond_to do |format|
       format.js
-      format.html { redirect_to user_fido_usf_registration_url }
+      format.html { redirect_to fido_usf_registration_url }
     end
   end
 
@@ -34,37 +36,53 @@ class Devise::FidoUsfRegistrationsController < ApplicationController
       reg = u2f.register!(session[:challenges], response)
 
       pubkey = reg.public_key
-      pubkey = Base64.decode64(reg.public_key) unless pubkey.bytesize == 65 && pubkey.byteslice(0) != "\x04" 
-      
+      pubkey = Base64.decode64(reg.public_key) unless pubkey.bytesize == 65 && pubkey.byteslice(0) != "\x04"
+
       @device = FidoUsf::FidoUsfDevice.create!(
-          user: current_user,
-          name: "Token ##{current_user.fido_usf_devices.count+1}",
-          certificate: reg.certificate,
-          key_handle: reg.key_handle,
-          public_key: pubkey,
-          counter: reg.counter,
-          last_authenticated_at: Time.now)
+        user: resource,
+        name: "Token ##{resource.fido_usf_devices.count + 1}",
+        certificate: reg.certificate,
+        key_handle: reg.key_handle,
+        public_key: pubkey,
+        counter: reg.counter,
+        last_authenticated_at: Time.now
+      )
       flash[:success] = I18n.t('fido_usf.flashs.device.registered')
     rescue U2F::Error => e
       @error_message = "Unable to register: #{e.class.name}"
-      flash[:error] = @error_message 
+      flash[:error] = @error_message
     ensure
       session.delete(:challenges)
     end
 
     respond_to do |format|
       format.js
-      format.html { redirect_to user_fido_usf_registration_url }
+      format.html { redirect_to fido_usf_registration_url }
     end
   end
 
   def update
-    device = current_user.fido_usf_devices.find(params[:id])
+    device = resource.fido_usf_devices.find(params[:id])
     device.update!(fido_usf_params)
     respond_to do |format|
       format.js
-      format.html { redirect_to user_fido_usf_registration_url }
+      format.html { redirect_to fido_usf_registration_url }
     end
+  end
+
+  if respond_to?(:helper_method)
+    helpers = %w[resource_name]
+    helper_method(*helpers)
+  end
+
+  protected
+
+  def resource_name
+    devise_mapping.name
+  end
+
+  def devise_mapping
+    @devise_mapping ||= request.env['devise.mapping']
   end
 
   private
@@ -77,5 +95,18 @@ class Devise::FidoUsfRegistrationsController < ApplicationController
   def u2f
     # use base_url as app_id, e.g. 'http://localhost:3000'
     @u2f ||= U2F::U2F.new(request.base_url)
+  end
+
+  def resource
+    send("current_#{resource_name}")
+  end
+
+  def authenticate_resource!
+    send("authenticate_#{resource_name}!")
+  end
+
+  def fido_usf_registration_url
+    params[:on_success_redirect_to].presence ||
+      send("#{resource_name}_fido_usf_registration_url")
   end
 end

--- a/app/views/devise/fido_usf_authentications/new.html.erb
+++ b/app/views/devise/fido_usf_authentications/new.html.erb
@@ -2,7 +2,7 @@
 <p>Please insert one of your registered keys and press the button within 15 seconds</p>
 <p id="waiting">Waiting...</p>
 <p id="error" style="display: none;"></p>
-<%= form_tag user_fido_usf_authentication_path(), method: 'post' do %>
+<%= form_tag send("#{resource_name}_fido_usf_authentication_path"), method: 'post' do %>
   <%= hidden_field_tag :response %>
 <% end %>
 <script>

--- a/app/views/devise/fido_usf_registrations/_device.html.erb
+++ b/app/views/devise/fido_usf_registrations/_device.html.erb
@@ -1,5 +1,5 @@
 <tr id="device_<%= device.id %>">
   <td><%= device.name %></td>
   <td><%= l(device.last_authenticated_at, format: :long) %></td>
-  <td><%= link_to 'Delete', user_fido_usf_registration_path(id: device.id), remote: true, :method => :delete, data: {confirm: "Should device #{device.name} be deleted?" } %></td>
+  <td><%= link_to 'Delete', send("#{resource_name}_fido_usf_registration_path", id: device.id), remote: true, method: :delete, data: { confirm: "Should device #{device.name} be deleted?" } %></td>
 </tr>

--- a/app/views/devise/fido_usf_registrations/new.html.erb
+++ b/app/views/devise/fido_usf_registrations/new.html.erb
@@ -3,7 +3,7 @@
 <p id="waiting">Waiting...</p>
 <p id="error" style="display: none;"></p>
 
-<%= form_tag user_fido_usf_registration_path(), method: 'post' do %>
+<%= form_tag send("#{resource_name}_fido_usf_registration_path"), method: 'post' do %>
   <%= hidden_field_tag :response %>
 <% end %>
 

--- a/app/views/devise/fido_usf_registrations/show.html.erb
+++ b/app/views/devise/fido_usf_registrations/show.html.erb
@@ -2,4 +2,4 @@
 <p>List of registered devices:</p>
 <%= render 'devise/fido_usf_registrations/devices' %>
 <p><%= link_to 'Back', root_path %></p>
-<p><%= link_to 'Add', new_user_fido_usf_registration_path %></p>
+<p><%= link_to 'Add', send("new_#{resource_name}_fido_usf_registration_path") %></p>

--- a/lib/devise_fido_usf/controllers/helpers.rb
+++ b/lib/devise_fido_usf/controllers/helpers.rb
@@ -7,22 +7,24 @@ module DeviseFidoUsf
 
       included do
         before_action :check_request_and_redirect_to_verify_fido_usf,
-                      if: :is_user_signing_in?
+                      if: :user_signing_in?
       end
 
       private
-      def is_devise_sessions_controller?
-        self.class == Devise::SessionsController || self.class.ancestors.include?(Devise::SessionsController)
+
+      def devise_sessions_controller?
+        self.class == Devise::SessionsController ||
+          self.class.ancestors.include?(Devise::SessionsController)
       end
 
-      def is_user_signing_in?
+      def user_signing_in?
         if devise_controller? && signed_in?(resource_name) &&
-          is_devise_sessions_controller? &&
-          self.action_name == "create"
+           devise_sessions_controller? &&
+           action_name == 'create'
           return true
         end
 
-        return false
+        false
       end
 
       def check_request_and_redirect_to_verify_fido_usf

--- a/lib/devise_fido_usf/models/fido_usf_registerable.rb
+++ b/lib/devise_fido_usf/models/fido_usf_registerable.rb
@@ -4,7 +4,10 @@ module Devise
       extend ActiveSupport::Concern
 
       included do
-        has_many :fido_usf_devices, class_name: 'FidoUsf::FidoUsfDevice', foreign_key: 'user_id', dependent: :destroy
+        has_many :fido_usf_devices,
+                 as: :user,
+                 class_name: 'FidoUsf::FidoUsfDevice',
+                 dependent: :destroy
       end
     end
   end

--- a/test/integration/fido_usf_authentications_test.rb
+++ b/test/integration/fido_usf_authentications_test.rb
@@ -3,12 +3,13 @@ require 'test_helper'
 class FidoUsfAuthenticationTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test "visit without 2fa" do
-    visit secret_path()
+  test 'visit without 2fa' do
+    visit secret_path
     assert_no_text 'secret page'
     assert_text 'Log in'
+
     sign_in_as_user
-    visit secret_path()
+    visit secret_path
     assert_text 'secret page'
   end
 
@@ -30,29 +31,29 @@ class FidoUsfAuthenticationTest < ActionDispatch::IntegrationTest
     assert_text 'secret page'
   end
 
-  test "visit with 2fa active" do
-    visit secret_path()
+  test 'visit with 2fa active' do
+    visit secret_path
     assert_no_text 'secret page'
     assert_text 'Log in'
 
     token = setup_u2f_with_appid(get_fake_ssl_hostname)
-    sign_in_as_user({usf_device: token})
+    sign_in_as_user(usf_device: token)
 
     assert_no_text 'secret page'
     assert_text 'Authenticate key'
 
-    visit secret_path()
+    visit secret_path
     assert_no_text 'secret page'
     assert_text 'Log in'
   end
 
-  test "visit with 2fa active and valid response" do
-    visit secret_path()
+  test 'visit with 2fa active and valid response' do
+    visit secret_path
     assert_no_text 'secret page'
     assert_text 'Log in'
 
     token = setup_u2f_with_appid(get_fake_ssl_hostname)
-    sign_in_as_user({usf_device: token})
+    sign_in_as_user(usf_device: token)
 
     assert_no_text 'secret page'
     assert_text 'Authenticate key'
@@ -64,39 +65,39 @@ class FidoUsfAuthenticationTest < ActionDispatch::IntegrationTest
     assert_text 'secret page'
   end
 
-  test "visit with 2fa active and valid response from two users" do
-    visit secret_path()
+  test 'visit with 2fa active and valid response from two users' do
+    visit secret_path
     assert_no_text 'secret page'
     assert_text 'Log in'
 
     token = setup_u2f_with_appid(get_fake_ssl_hostname)
-    sign_in_as_user_with_token({email: 'other@test.com', usf_device: token})
+    sign_in_as_user_with_token(email: 'other@test.com', usf_device: token)
 
     assert_text 'secret page'
     sign_out_as_user
 
-    visit secret_path()
+    visit secret_path
     assert_no_text 'secret page'
     assert_text 'Log in'
 
     token = setup_u2f_with_appid(get_fake_ssl_hostname)
-    sign_in_as_user_with_token({usf_device: token})
+    sign_in_as_user_with_token(usf_device: token)
 
     assert_text 'secret page'
     sign_out_as_user
   end
 
-  test "visit with 2fa active and other user is using wrong token" do
-    visit secret_path()
+  test 'visit with 2fa active and other user is using wrong token' do
+    visit secret_path
     assert_no_text 'secret page'
     assert_text 'Log in'
 
     token = setup_u2f_with_appid(get_fake_ssl_hostname)
-    sign_in_as_user_with_token({email: 'other@test.com', usf_device: token})
+    sign_in_as_user_with_token(email: 'other@test.com', usf_device: token)
     assert_text 'secret page'
     sign_out_as_user
 
-    visit secret_path()
+    visit secret_path
     new_token = setup_u2f_with_appid(get_fake_ssl_hostname)
     sign_in_as_user(usf_device: new_token)
     assert_text 'Authenticate key'
@@ -107,27 +108,28 @@ class FidoUsfAuthenticationTest < ActionDispatch::IntegrationTest
     assert_empty page.body
   end
 
-  test "visit with 2fa active and user is using two tokens" do
-    visit secret_path()
+  test 'visit with 2fa active and user is using two tokens' do
+    visit secret_path
     assert_no_text 'secret page'
     assert_text 'Log in'
 
     token_a = setup_u2f_with_appid(get_fake_ssl_hostname)
     token_b = setup_u2f_with_appid(get_fake_ssl_hostname)
-    user = sign_in_as_user_with_token({usf_device: token_a})
-    create_u2f_device(user, token_b[:key_handle], token_b[:public_key], token_b[:certificate])
-    assert_equal 2, user.fido_usf_devices.count()
+    user = sign_in_as_user_with_token(usf_device: token_a)
+    create_u2f_device(user, token_b[:key_handle], token_b[:public_key],
+                      token_b[:certificate])
+    assert_equal 2, user.fido_usf_devices.count
 
     assert_text 'secret page'
     sign_out_as_user
 
-    visit secret_path()
-    sign_in_as_existing_user_with_token(user, {usf_device: token_a})
+    visit secret_path
+    sign_in_as_existing_user_with_token(user, usf_device: token_a)
     assert_text 'secret page'
     sign_out_as_user
 
-    visit secret_path()
-    sign_in_as_existing_user_with_token(user, {usf_device: token_b})
+    visit secret_path
+    sign_in_as_existing_user_with_token(user, usf_device: token_b)
     assert_text 'secret page'
     sign_out_as_user
   end


### PR DESCRIPTION
 - This modification updates the routes, controllers, and views in order to be able to use other models than User (I.e: AdminUser from ActiveAdmin gem)
 - Fixes the `has_many :fido_usf_devices ` association (before wasn't filtering on the `user_type` so a `User` with ID `1` and an `AdminUser` with ID `1` was having the same keys
 - Allows passing a `on_success_redirect_to` parameter in order to redirect somewhere else after the action (In my case, from ActiveAdmin I allow an AdminUser to delete a key for a `User`, and I want to stay in ActiveAdmin)